### PR TITLE
chore: update dependency node-sass to v4.12.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "eslint": "5.0.0",
     "eslint-plugin-vue": "5.2.2",
     "moment": "2.24.0",
-    "node-sass": "4.11.0",
+    "node-sass": "4.12.0",
     "sass-loader": "7.1.0",
     "vuepress": "1.0.0-alpha.47"
   }


### PR DESCRIPTION
支持 Node.js 12
sass/node-sass#2632

另外，`template` 分支的 `package.json` 文件，[声明了 `vuepress-theme-indigo-material` 的依赖](https://github.com/zhhlwd/vuepress-theme-indigo-material/blob/template/package.json#L15)，还需要保持其他项和 `master` 一致吗？